### PR TITLE
Add 20s IdleConnTimeout to HttpClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 accessTokens.ps1
+config.toml

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	colorable "github.com/mattn/go-colorable"
@@ -129,9 +130,9 @@ func main() {
 
 		if server.UseProxy {
 			log.WithFields(log.Fields{"server": server.Name, "serverAddress": server.Address}).Info("Proxy will be used")
-			server.client = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+			server.client = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL), IdleConnTimeout: time.Second * 20}}
 		} else {
-			server.client = &http.Client{}
+			server.client = &http.Client{Transport: &http.Transport{IdleConnTimeout: time.Second * 20}}
 		}
 
 		tfsCollectors = append(tfsCollectors, newTFSCollector(server.tfs, ignoreHostedPools))


### PR DESCRIPTION
When running against IIS the Exporter was receiving unexpected data
through the idle connection, this only occured with IIS. Therefore we
will close the connection earlier.

This commit adds an idle connection timeout of 20s to the HttpClient by
default.