### PR TITLE
Add Queue Depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,6 @@ Set the promethus scrape timeout to be larger than 10 seconds as scrapes can som
   - Gauge of the total installed build agents. Has labels of `"enabled", "status", "pool" "name"`
 - tfs_build_agents_total_scrape_duration_seconds
   - Gauge of duration of time it took to scrape total of installed build agents. Has labels of `"name"`
+- tfs_pool_queued_jobs
+  - Gauge of the total of queued jobs for pool. Has labels of `"pool"`
+  - A queued job is a job that has not yet started. If you have 6 build agents and 7 jobs, 6 jobs will be assigned to the agents, leaving one not started. `tfs_pool_queued_jobs` will then display `1`

--- a/job.go
+++ b/job.go
@@ -1,0 +1,18 @@
+package main
+
+import "time"
+
+type jobResponseEnvelope struct {
+	Count int   `json:"count"`
+	Jobs  []job `json:"value"`
+}
+
+type job struct {
+	RequestID   int       `json:"requestId"`
+	Name        string    `json:"name"`
+	QueueTime   time.Time `json:"queueTime"`
+	AssignTime  time.Time `json:"assignTime"`
+	ReceiveTime time.Time `json:"receiveTime"`
+	JobID       string    `json:"jobId"`
+	PlanType    string    `json:"planType"`
+}

--- a/tfs.go
+++ b/tfs.go
@@ -24,7 +24,7 @@ type tfs struct {
 
 func (t *tfs) agents(poolID int) ([]agent, error) {
 
-	//Build request
+	// Build request
 	var url = t.buildURL("/_apis/distributedtask/pools/" + strconv.Itoa(poolID) + "/agents?includeCapabilities=false&includeAssignedRequest=true")
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -33,13 +33,13 @@ func (t *tfs) agents(poolID int) ([]agent, error) {
 	}
 	req.SetBasicAuth("", t.AccessToken)
 
-	//Make request
+	// Make request
 	responseData, err := t.makeRequest(req)
 	if err != nil {
 		return []agent{}, err
 	}
 
-	//	Turn response into JSON
+	// Turn response into JSON
 	are := agentResponseEnvelope{}
 	err = json.Unmarshal(responseData, &are)
 	if err != nil {
@@ -95,7 +95,7 @@ func (t *tfs) pools(ignoreHosted bool) ([]pool, error) {
 }
 
 func (t *tfs) currentJobs(poolID int) ([]job, error) {
-	//Build request
+	// Build request
 	var url = t.buildURL("/_apis/distributedtask/pools/" + strconv.Itoa(poolID) + "/jobrequests/?completedRequestCount=0")
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -104,13 +104,13 @@ func (t *tfs) currentJobs(poolID int) ([]job, error) {
 	}
 	req.SetBasicAuth("", t.AccessToken)
 
-	//Make request
+	// Make request
 	responseData, err := t.makeRequest(req)
 	if err != nil {
 		return []job{}, err
 	}
 
-	//	Turn response into type from JSON
+	// Turn response into type from JSON
 	jre := jobResponseEnvelope{}
 	err = json.Unmarshal(responseData, &jre)
 	if err != nil {

--- a/tfs.go
+++ b/tfs.go
@@ -94,6 +94,32 @@ func (t *tfs) pools(ignoreHosted bool) ([]pool, error) {
 	return pre.Pools, nil
 }
 
+func (t *tfs) currentJobs(poolID int) ([]job, error) {
+	//Build request
+	var url = t.buildURL("/_apis/distributedtask/pools/" + strconv.Itoa(poolID) + "/jobrequests/?completedRequestCount=0")
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return []job{}, fmt.Errorf("Could not generate request to find all queued jobs %v", err)
+	}
+	req.SetBasicAuth("", t.AccessToken)
+
+	//Make request
+	responseData, err := t.makeRequest(req)
+	if err != nil {
+		return []job{}, err
+	}
+
+	//	Turn response into type from JSON
+	jre := jobResponseEnvelope{}
+	err = json.Unmarshal(responseData, &jre)
+	if err != nil {
+		return []job{}, fmt.Errorf("Failed to convert to JSON - %v", err)
+	}
+
+	return jre.Jobs, nil
+}
+
 func (t *tfs) makeRequest(req *http.Request) ([]byte, error) {
 
 	var (


### PR DESCRIPTION
This PR implements a new metric - `tfs_pool_queued_jobs`

This metric exposes the current number of queued jobs per pool as a gauge. A queued job is a job that has not yet started. If you have 6 build agents and 7 jobs, 6 jobs will be assigned to the agents, leaving one not started. `tfs_pool_queued_jobs` will then display `1`.

This metric has been implemented as it is very hard to discover whether self hosted agents are being fully saturated via the AzureDevOps UI, espically across numerous pools and numerous instances of AzureDevOps in real time. It is doubly hard to look retroactively and discover how many jobs were queued at a single time.

This PR has also refactored the pipeline to be allow additional metrics to be added easier by removing the `formatMetrics` function and combining it with the the `calculateMetrics` Further work is needed to refactor the project further.